### PR TITLE
Auto-follow new projects for listed admins

### DIFF
--- a/Common/conf/conf.template.ini
+++ b/Common/conf/conf.template.ini
@@ -47,6 +47,7 @@ cookie_timeout='60 minutes' ;has to be convertible to UNIX timestamp - uses strt
 extended_cookie_timeout='2 weeks' ;has to be convertible to UNIX timestamp - uses strtotime() if a string
 default_site_language_code='en'
 oauth_timeout=3600 ; seconds
+autofollow_admin_ids= ; comma separated list of user_id-s, which will be automatically following new projects
 
 [maintenance]
 maintenance_duration = '2'        ;maintenance duration in hours (used in both site wide maintenance and message options below)
@@ -56,9 +57,9 @@ maintenance_mode = 'n'		      ;put the entire site into maintenance mode (this f
 maintenance_msg = 'n'			  ;turn on only the scheduled maintenance message (default = 'n')
 maintenance_date = '14/01/2014'   ;maintenance start date
 maintenance_time = '15:00'	      ;maintenance start time (GMT)
-maintenance_custom_msg = 'n'      ;show a custom maintenance message (to turn on this feature set both maintenance_msg and maintenance_custom_msg to 'y') 
+maintenance_custom_msg = 'n'      ;show a custom maintenance message (to turn on this feature set both maintenance_msg and maintenance_custom_msg to 'y')
 ;setting maintenance_custom_msg to 'y' will override the default maintenance message and display the message entered below.
-maintenance_custom_message= 'custome message goes here' 
+maintenance_custom_message= 'custome message goes here'
 
 [banner]
 ;banner divided into three parts: left, mid, right
@@ -98,7 +99,7 @@ workflow_graphs='y' ;y or n
 site_key='i91hbc897ayb3e7ycayvgxouqgy8<F7>a9<F2>pwjq897<F2>t13bil;ubqw;cxo98ba97y2703y3'
 
 [oauth]
-;From the spec "It is recommended that you make the id and secret fields random alphanumeric strings - 
+;From the spec "It is recommended that you make the id and secret fields random alphanumeric strings -
 ;http://randomkeygen.com/ is a useful [tool] for this". They should be 40 Chars in length
 client_id='yub78q7gabcku73FK47A4AIFK7GAK7UGFAK4'
 client_secret='sfvg7gir74bi7ybawQFNJUMSDCPOPi7u238OH88rfi'

--- a/api/v0/Projects.php
+++ b/api/v0/Projects.php
@@ -337,8 +337,10 @@ class Projects
     {
         $result = array();
         try {
-            $adminIdsString = Common\Lib\Settings::get('site.autofollow_admin_ids');
-            $result = array_map('intval', explode(',', $adminIdsString));
+            $adminIdsString = trim(Common\Lib\Settings::get('site.autofollow_admin_ids'));
+            if ($adminIdsString) {
+                $result = array_map('intval', explode(',', $adminIdsString));
+            }
         } catch(Exception $e) {
             error_log($e->getMessage());
         }

--- a/vagrant/assets/conf.ini
+++ b/vagrant/assets/conf.ini
@@ -51,6 +51,7 @@ default_site_language_code='en'
 oauth_timeout=3600 ; seconds
 log="/tmp/output.log"
 max_threads=15
+autofollow_admin_ids=1,2,3
 
 [maintenance]
 maintenance_duration = '2'        ;maintenance duration in hours (used in both site wide maintenance and message options below)


### PR DESCRIPTION
#1245 Calls `trackProject` for user ids defined in `conf.ini` section`site.autofollow_admin_ids`.

Note: the extra changes in `conf.template.ini` are removed trailing space.

RFR @alanbarrett 