### PR TITLE
Fix AJAX url for vagrant box

### DIFF
--- a/vagrant/assets/conf.ini
+++ b/vagrant/assets/conf.ini
@@ -27,7 +27,7 @@ virtualhost=/
 poll_rate=250
 
 [site]
-location='http://127.0.0.1/solas-match/'	  ;site location (for dart)
+location='/'	  ;site location (for dart)
 api='http://127.0.0.1/api/'       ;The location of the API
 name='SOLAS Match'
 title='Trommons | Translation Commons'    ; Default value for the <title></title> tag.


### PR DESCRIPTION
`site.location` is used for AJAX calls. Settings it to the site root, fixes the AJAX calls for the vagrant box.

RFR @alanbarrett 